### PR TITLE
fixes #45

### DIFF
--- a/lib/flat.js
+++ b/lib/flat.js
@@ -75,6 +75,24 @@ const pitchesToRests = (pieceScoreJSON) => {
         },
       }),
     );
+
+    // last step of theoretical for Bb Melody Freedom 20240 Band wouldn't load.
+    // looks like comparing Concert Pitch TC to Bb for this part,
+    // the Bb version has 2 harmonies notated in a single measure,
+    // but the Concert Pitch TC never has 2 harmonies
+    // current hypothesis: in the steps above we potentially change
+    // the duration of the measures. this could be the issue: only in measures
+    // that have multiple harmonies, the second harmony would have
+    // its timePos > 0 but we don't currently re-compute it,
+    // so it ends up out of bounds in some cases
+    if (measure?.harmony?.length > 1) {
+      const harmonyDuration = currentTimeSig.duration;
+      measure.harmony.forEach((harmony, j) => {
+        measuresRef[i].harmony[j]['$adagio-location'] = {
+          timePos: j * harmonyDuration,
+        };
+      });
+    }
   });
   return composeScoreJSON;
 };


### PR DESCRIPTION
in measures with multiple harmonies (e.g. measure 15 of `Freedom 2040: The Tomorrow We'll Build Melody - Bb`), it's possible that our recalculation of `duration` and `timePos` for notes results in out of bounds exceptions for harmonies. This should resolve that issues (it fixes the prod issue in local testing)