### PR TITLE
log missing operations in isStepComplete debug output

### DIFF
--- a/lib/activity/activityConstants.js
+++ b/lib/activity/activityConstants.js
@@ -176,12 +176,15 @@ export function isStepComplete(stepNumber, completedOperations, activityLogs = [
   const totalCompletedCount = completedCount + alternateCount;
   const isComplete = totalCompletedCount >= requirements.minRequired;
 
+  const missingOps = requirements.required.filter(op => !completed.includes(op));
+
   console.log('🔍 isStepComplete result:', {
     completedCount,
     alternateCount,
     totalCompletedCount,
     minRequired: requirements.minRequired,
     isComplete,
+    missingOps,
   });
 
   return isComplete;


### PR DESCRIPTION
## Summary
- Adds `missingOps` to the `isStepComplete` console log so we can immediately see which required operation(s) are preventing step completion