### PR TITLE
fix takes_imported never logged from TakesImportModal

### DIFF
--- a/components/audio/DAW/Multitrack/MultitrackEditor.js
+++ b/components/audio/DAW/Multitrack/MultitrackEditor.js
@@ -1212,7 +1212,7 @@ export default function MultitrackEditor({ availableTakes: propTakes = [], logOp
         show={showTakesModal}
         onHide={() => setShowTakesModal(false)}
         takes={availableTakes}
-        onImport={handleImportTake}
+        logOperation={logOperation}
       />
 
       {/* Clip Effects Modal */}

--- a/components/audio/DAW/Multitrack/TakesImportModal.js
+++ b/components/audio/DAW/Multitrack/TakesImportModal.js
@@ -7,7 +7,7 @@ import { FaFileAudio, FaClock, FaMusic } from 'react-icons/fa';
 import { useMultitrack } from '../../../../contexts/MultitrackContext';
 import { getAudioProcessor } from './AudioProcessor';
 
-export default function TakesImportModal({ show, onHide, takes = [] }) {
+export default function TakesImportModal({ show, onHide, takes = [], logOperation = null }) {
   const { addTrack, updateTrack } = useMultitrack();
   const [selectedTake, setSelectedTake] = useState(null);
   const [trackName, setTrackName] = useState('');
@@ -126,6 +126,10 @@ export default function TakesImportModal({ show, onHide, takes = [] }) {
       });
 
       console.log('🎵 TakesImportModal: Track created immediately with ID:', newTrack.id);
+
+      if (logOperation) {
+        logOperation('takes_imported', { takeName: selectedTake.name || trackName });
+      }
 
       // Close modal immediately - track is already visible
       setSelectedTake(null);


### PR DESCRIPTION
## Summary
- `TakesImportModal` bypasses the `onImport` callback entirely — it calls `addTrack` directly via context, so the `takes_imported` operation was never logged
- This blocked Activity 3 completion (11/12 operations, stuck at 92%)
- Added `logOperation('takes_imported')` directly in the modal and removed the dead `onImport` prop