### PR TITLE
Disable dropped-audio submit check by default

### DIFF
--- a/components/recorder.js
+++ b/components/recorder.js
@@ -80,7 +80,12 @@ const createSilentAudio = () => {
 
 const scratchURL = createSilentAudio();
 
-export default function RecorderRefactored({ submit, accompaniment, logOperation = null }) {
+export default function RecorderRefactored({
+  submit,
+  accompaniment,
+  logOperation = null,
+  enableDroppedAudioDetection = false,
+}) {
   const dispatch = useDispatch();
   const router = useRouter();
   const { slug, piece, actCategory, partType } = router.query;
@@ -535,7 +540,9 @@ export default function RecorderRefactored({ submit, accompaniment, logOperation
       }
 
       try {
-        if (!ignoreSilence && ffmpegLoaded) {
+        // Keep dropped-audio detection available as an opt-in tool without
+        // blocking the default student submit flow.
+        if (enableDroppedAudioDetection && !ignoreSilence && ffmpegLoaded) {
           const silenceResult = await catchSilence(
             ffmpegRef,
             url,
@@ -593,6 +600,7 @@ export default function RecorderRefactored({ submit, accompaniment, logOperation
       }
     },
     [
+      enableDroppedAudioDetection,
       ignoreSilence,
       ffmpegLoaded,
       ffmpegRef,
@@ -726,7 +734,7 @@ export default function RecorderRefactored({ submit, accompaniment, logOperation
         </Col>
       </Row>
       <AudioDropModal
-        show={showAudioDrop}
+        show={enableDroppedAudioDetection && showAudioDrop}
         silenceData={silenceData}
         onIgnore={() => {
           setIgnoreSilence(true);


### PR DESCRIPTION
## Summary
- disable dropped-audio detection in normal recorder submit flows by default
- keep the dropped-audio detection code and warning modal in place
- make detection opt-in via the Recorder prop `enableDroppedAudioDetection`

## Why
Normal student recording submits were still invoking the dropped-audio scan and could be blocked by the warning flow. This change keeps the feature available without firing during the regular activity submit path.

## Opt in
If we still want pre-submit dropped-audio scanning in a specific flow, render the recorder with:

`<Recorder enableDroppedAudioDetection />`

That re-enables the existing `catchSilence(...)` pre-submit check and warning modal for that recorder instance.
