### PR TITLE
fix(SandboxSynth): pass index to unison voices forEach

### DIFF
--- a/components/audio/InstrumentSandbox/SandboxSynth.js
+++ b/components/audio/InstrumentSandbox/SandboxSynth.js
@@ -779,7 +779,7 @@ class SandboxSynth {
     }
 
     // Process each unison voice
-    voices.forEach(voice => {
+    voices.forEach((voice, i) => {
       const voiceId = voice.id;
 
     // Create oscillator mixer


### PR DESCRIPTION
## Summary
- `voices.forEach(voice => {...})` at `components/audio/InstrumentSandbox/SandboxSynth.js:782` was missing the index argument, but the body still referenced `i` from an earlier `for (let i...)` loop used to build the `voices` array.
- Result: `ReferenceError: i is not defined` when starting a unison voice — reproduced by a tester entering Arco from the Studio modal.
- Fix takes the index directly from the forEach callback. Inner `for (let i...)` loops in the body each declare their own `i`, so no shadowing.

Worth manually verifying: open the Studio modal, select Arco, play a note, and confirm no runtime error. With `unisonVoices > 1`, check that the `[SandboxSynth] Started voice N (k/numVoices)` log lines report correct indices.